### PR TITLE
v2raya-unstable: Update version to 20221004.r1225.11aa2b0

### DIFF
--- a/bucket/v2raya-git.json
+++ b/bucket/v2raya-git.json
@@ -25,11 +25,14 @@
         }
     },
     "pre_install": [
-        "info '[Portable Mode]: Copying user data...'",
-        "if (Test-Path \"$persist_dir\\*\") {",
-        "    ensure \"$env:UserProfile\\.config\\v2raya\" | Out-Null",
-        "    Copy-Item \"$persist_dir\\*\" \"$env:UserProfile\\.config\\v2raya\\\" -Recurse -Force | Out-Null",
-        "}"
+        "if (Test-Path \"$env:UserProfile\\.config\\v2raya\") {",
+        "    info '[Persistent data]: Copying user data...'",
+        "    ensure \"$persist_dir\" | Out-Null",
+        "    Copy-Item \"$env:UserProfile\\.config\\v2raya\\*\" \"$persist_dir\\\" -ErrorAction SilentlyContinue -Recurse -Force",
+        "    Remove-Item \"$env:UserProfile\\.config\\v2raya\" -ErrorAction SilentlyContinue -Recurse -Force",
+        "}",
+        "ensure \"$persist_dir\" | Out-Null",
+        "New-Item \"$env:UserProfile\\.config\\v2raya\" -ItemType Junction -Target \"$persist_dir\" | Out-Null"
     ],
     "installer": {
         "script": [
@@ -83,16 +86,10 @@
             "Set-Content \"$dir\\stop-v2raya-git.ps1\" -Value 'taskkill.exe /IM v2rayawin-git.exe' -Encoding Ascii"
         ]
     },
-    "uninstaller": {
-        "script": [
-            "info '[Portable Mode]: Backing up user data...'",
-            "if (Test-Path \"$env:UserProfile\\.config\\v2raya\\*\") {",
-            "    ensure \"$persist_dir\" | Out-Null",
-            "    Copy-Item \"$env:UserProfile\\.config\\v2raya\\*\" \"$persist_dir\\\" -Recurse -Force | Out-Null",
-            "}",
-            "#Remove-Item \"$env:UserProfile\\.config\\v2raya\" -ErrorAction 'SilentlyContinue' -Force -Recurse"
-        ]
-    },
+    "pre_uninstall": [
+        "stop-v2raya-git",
+        "Remove-Item \"$env:UserProfile\\.config\\v2raya\" -ErrorAction 'SilentlyContinue' -Force -Recurse"
+    ],
     "bin": [
         [
             "v2rayaWin-git.exe",
@@ -115,7 +112,11 @@
         "replace": "${1}${2}${3}.${short}"
     },
     "autoupdate": {
-        "url": "https://github.com/v2rayA/v2rayA/archive/$matchSha.zip",
-        "extract_dir": "v2rayA-$matchSha"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/v2rayA/v2rayA/archive/$matchSha.zip",
+                "extract_dir": "v2rayA-$matchSha"
+            }
+        }
     }
 }

--- a/bucket/v2raya-unstable.json
+++ b/bucket/v2raya-unstable.json
@@ -1,5 +1,5 @@
 {
-    "version": "20220928.r1200.744282e",
+    "version": "20221004.r1225.11aa2b0",
     "description": "v2rayA is a V2Ray client supporting global transparent proxy(Linux Only), compatible with SS, SSR, Trojan(trojan-go), PingTunnel protocols.",
     "homepage": "https://github.com/v2rayA/v2raya",
     "license": {
@@ -13,30 +13,26 @@
     },
     "architecture": {
         "64bit": {
-            "url": "https://nightly.link/v2rayA/v2rayA/actions/runs/3141970275/v2raya_windows_x64_unstable-20220928.r1200.744282e.exe.zip",
-            "hash": "e6bd61ab774e060df41a29e0820ad4dd0e5cc8a3cd8fd778886fd7620dd16d74",
+            "url": "https://nightly.link/v2rayA/v2rayA/actions/runs/3179664672/v2raya_windows_x64_unstable-20221004.r1225.11aa2b0.exe.zip",
+            "hash": "0d9e3faadaf1fbd2ff4c01a49ed6bb30769e9d5970da62af470bdc5241cb4b23",
             "pre_install": [
                 "Rename-Item \"$dir\\v2raya_windows_x64_unstable-$version.exe\" 'v2rayaWin-unstable.exe' -ErrorAction 'SilentlyContinue' -Force",
-                "info '[Portable Mode]: Copying user data...'",
-                "if (Test-Path \"$persist_dir\\*\") {",
-                "    ensure \"$env:UserProfile\\.config\\v2raya\" | Out-Null",
-                "    Copy-Item \"$persist_dir\\*\" \"$env:UserProfile\\.config\\v2raya\\\" -Recurse -Force | Out-Null",
+                "if (Test-Path \"$env:UserProfile\\.config\\v2raya\") {",
+                "    info '[Persistent data]: Copying user data...'",
+                "    ensure \"$persist_dir\" | Out-Null",
+                "    Copy-Item \"$env:UserProfile\\.config\\v2raya\\*\" \"$persist_dir\\\" -ErrorAction SilentlyContinue -Recurse -Force",
+                "    Remove-Item \"$env:UserProfile\\.config\\v2raya\" -ErrorAction SilentlyContinue -Recurse -Force",
                 "}",
+                "ensure \"$persist_dir\" | Out-Null",
+                "New-Item \"$env:UserProfile\\.config\\v2raya\" -ItemType Junction -Target \"$persist_dir\" | Out-Null",
                 "Set-Content \"$dir\\start-v2raya-unstable.ps1\" -Value 'Start-Process -FilePath \"$(scoop prefix v2raya-unstable)\\v2rayaWin-unstable.exe\" -ArgumentList @(\"--lite\", \"--log-file v2raya-unstable.log\") -WorkingDirectory \"$env:TEMP\" -WindowStyle Hidden' -Encoding Ascii",
                 "Set-Content \"$dir\\stop-v2raya-unstable.ps1\" -Value 'taskkill.exe /IM v2rayawin-unstable.exe' -Encoding Ascii"
+            ],
+            "pre_uninstall": [
+                "stop-v2raya-unstable",
+                "Remove-Item \"$env:UserProfile\\.config\\v2raya\" -ErrorAction 'SilentlyContinue' -Force -Recurse"
             ]
         }
-    },
-    "uninstaller": {
-        "script": [
-            "stop-v2raya-unstable",
-            "info '[Portable Mode]: Backing up user data...'",
-            "if (Test-Path \"$env:UserProfile\\.config\\v2raya\\*\") {",
-            "    ensure \"$persist_dir\" | Out-Null",
-            "    Copy-Item \"$env:UserProfile\\.config\\v2raya\\*\" \"$persist_dir\\\" -Recurse -Force | Out-Null",
-            "}",
-            "#Remove-Item \"$env:UserProfile\\.config\\v2raya\" -ErrorAction 'SilentlyContinue' -Force -Recurse"
-        ]
     },
     "bin": [
         [
@@ -60,6 +56,10 @@
         "replace": "${ver}"
     },
     "autoupdate": {
-        "url": "https://nightly.link/v2rayA/v2rayA/actions/runs/$matchRunid/$matchFilename.zip"
+        "architecture": {
+            "64bit": {
+                "url": "https://nightly.link/v2rayA/v2rayA/actions/runs/$matchRunid/$matchFilename.zip"
+            }
+        }
     }
 }

--- a/bucket/v2raya.json
+++ b/bucket/v2raya.json
@@ -13,32 +13,24 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/v2rayA/v2rayA/releases/download/v1.5.9.1698.1/v2raya_windows_x64_1.5.9.1698.1.exe#/v2rayaWin.exe",
-            "hash": "5e764e82723e55d9a3446769a7a07427404a28d51e952a693a503caff8d422e0"
+            "hash": "5e764e82723e55d9a3446769a7a07427404a28d51e952a693a503caff8d422e0",
+            "pre_install": [
+                "if (Test-Path \"$env:UserProfile\\.config\\v2raya\") {",
+                "    info '[Persistent data]: Copying user data...'",
+                "    ensure \"$persist_dir\" | Out-Null",
+                "    Copy-Item \"$env:UserProfile\\.config\\v2raya\\*\" \"$persist_dir\\\" -ErrorAction SilentlyContinue -Recurse -Force",
+                "    Remove-Item \"$env:UserProfile\\.config\\v2raya\" -ErrorAction SilentlyContinue -Recurse -Force",
+                "}",
+                "ensure \"$persist_dir\" | Out-Null",
+                "New-Item \"$env:UserProfile\\.config\\v2raya\" -ItemType Junction -Target \"$persist_dir\" | Out-Null",
+                "Set-Content \"$dir\\start-v2raya.ps1\" -Value 'Start-Process -FilePath \"$(scoop prefix v2raya)\\v2rayaWin.exe\" -ArgumentList @(\"--lite\", \"--log-file v2raya.log\") -WorkingDirectory \"$env:TEMP\" -WindowStyle Hidden' -Encoding Ascii",
+                "Set-Content \"$dir\\stop-v2raya.ps1\" -Value 'taskkill.exe /IM v2rayawin.exe' -Encoding Ascii"
+            ],
+            "pre_uninstall": [
+                "stop-v2raya",
+                "Remove-Item \"$env:UserProfile\\.config\\v2raya\" -ErrorAction 'SilentlyContinue' -Force -Recurse"
+            ]
         }
-    },
-    "installer": {
-        "script": [
-            "#ensure \"$persist_dir\" | Out-Null",
-            "#New-Item \"$env:UserProfile\\.config\\v2raya\" -ItemType Junction -Target \"$persist_dir\" | Out-Null",
-            "info '[Portable Mode]: Copying user data...'",
-            "if (Test-Path \"$persist_dir\\*\") {",
-            "    ensure \"$env:UserProfile\\.config\\v2raya\" | Out-Null",
-            "    Copy-Item \"$persist_dir\\*\" \"$env:UserProfile\\.config\\v2raya\\\" -Recurse -Force | Out-Null",
-            "}",
-            "Set-Content \"$dir\\start-v2raya.ps1\" -Value 'Start-Process -FilePath \"$(scoop prefix v2raya)\\v2rayaWin.exe\" -ArgumentList @(\"--lite\", \"--log-file v2raya.log\") -WorkingDirectory \"$env:TEMP\" -WindowStyle Hidden' -Encoding Ascii",
-            "Set-Content \"$dir\\stop-v2raya.ps1\" -Value 'taskkill.exe /IM v2rayawin.exe' -Encoding Ascii"
-        ]
-    },
-    "uninstaller": {
-        "script": [
-            "stop-v2raya",
-            "info '[Portable Mode]: Backing up user data...'",
-            "if (Test-Path \"$env:UserProfile\\.config\\v2raya\\*\") {",
-            "    ensure \"$persist_dir\" | Out-Null",
-            "    Copy-Item \"$env:UserProfile\\.config\\v2raya\\*\" \"$persist_dir\\\" -Recurse -Force | Out-Null",
-            "}",
-            "#Remove-Item \"$env:UserProfile\\.config\\v2raya\" -ErrorAction 'SilentlyContinue' -Force -Recurse"
-        ]
     },
     "bin": [
         [


### PR DESCRIPTION

- fix autoupdate.architecture.
- Switch to feat_v5 branch.
- Update version to 20221004.r1225.11aa2b0
- migrate existing actions from uninstaller.scripts. This pre_uninstall script detects and stops v2raya service before updating/uninstalling the app.
- wrap $env:UserProfile\.config\v2raya to $persist_dir

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
