### PR TITLE
v2raya-unstable-np: add verssion 20221004.r1.11aa2b0

### DIFF
--- a/bucket/v2raya-unstable-np.json
+++ b/bucket/v2raya-unstable-np.json
@@ -32,7 +32,7 @@
             "Start-Process \"$dir\\unins000.exe\" -ArgumentList @('/VERYSILENT', '/NORESTART') -Wait -Verb RunAs",
             "if ($global) { $startmenu = 'CommonStartMenu' } else { $startmenu = 'StartMenu' }",
             "$scoop_startmenu_folder = [System.IO.Path]::Combine([Environment]::GetFolderPath($startmenu), 'Programs', 'Scoop Apps')",
-            "Remove-Item \"$scoop_startmenu_folder\\v2rayA\" -ErrorAction SilentlyContinue -Force -Recurse"
+            "Remove-Item \"$scoop_startmenu_folder\\v2rayA\" -Recurse -Force -ErrorAction 'SilentlyContinue'"
         ]
     },
     "bin": "v2rayA-service.exe",


### PR DESCRIPTION
v2raya-unstable-np: add verssion 20221004.r1.11aa2b0

- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
